### PR TITLE
add basic caching

### DIFF
--- a/packages/flex-plugins-api-client/src/clients/__tests__/configurations.test.ts
+++ b/packages/flex-plugins-api-client/src/clients/__tests__/configurations.test.ts
@@ -28,7 +28,7 @@ describe('ConfigurationsClient', () => {
 
     expect(result).toEqual('item');
     expect(get).toHaveBeenCalledTimes(1);
-    expect(get).toHaveBeenCalledWith('Configurations/configId');
+    expect(get).toHaveBeenCalledWith('Configurations/configId', { cacheable: true });
   });
 
   it('should create configurations', async () => {

--- a/packages/flex-plugins-api-client/src/clients/__tests__/configuredPluginsClient.test.ts
+++ b/packages/flex-plugins-api-client/src/clients/__tests__/configuredPluginsClient.test.ts
@@ -17,7 +17,7 @@ describe('ConfiguredPluginsClient', () => {
 
     expect(result).toEqual('list');
     expect(get).toHaveBeenCalledTimes(1);
-    expect(get).toHaveBeenCalledWith('Configurations/configId/Plugins');
+    expect(get).toHaveBeenCalledWith('Configurations/configId/Plugins', { cacheable: true });
   });
 
   it('should get configured plugin', async () => {
@@ -27,6 +27,6 @@ describe('ConfiguredPluginsClient', () => {
 
     expect(result).toEqual('item');
     expect(get).toHaveBeenCalledTimes(1);
-    expect(get).toHaveBeenCalledWith('Configurations/configId/Plugins/pluginId');
+    expect(get).toHaveBeenCalledWith('Configurations/configId/Plugins/pluginId', { cacheable: true });
   });
 });

--- a/packages/flex-plugins-api-client/src/clients/__tests__/pluginVersions.test.ts
+++ b/packages/flex-plugins-api-client/src/clients/__tests__/pluginVersions.test.ts
@@ -39,7 +39,7 @@ describe('PluginVersionsClient', () => {
 
     expect(result).toEqual('item');
     expect(get).toHaveBeenCalledTimes(1);
-    expect(get).toHaveBeenCalledWith('Plugins/pluginId/Versions/versionId');
+    expect(get).toHaveBeenCalledWith('Plugins/pluginId/Versions/versionId', { cacheable: true });
   });
 
   it('should create plugin version', async () => {

--- a/packages/flex-plugins-api-client/src/clients/__tests__/plugins.test.ts
+++ b/packages/flex-plugins-api-client/src/clients/__tests__/plugins.test.ts
@@ -30,7 +30,7 @@ describe('PluginsClient', () => {
 
     expect(result).toEqual('item');
     expect(get).toHaveBeenCalledTimes(1);
-    expect(get).toHaveBeenCalledWith('Plugins/pluginId');
+    expect(get).toHaveBeenCalledWith('Plugins/pluginId', { cacheable: true });
   });
 
   it('should update plugin', async () => {
@@ -64,7 +64,7 @@ describe('PluginsClient', () => {
 
       expect(result).toEqual('existing-plugin');
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('Plugins/the-name');
+      expect(get).toHaveBeenCalledWith('Plugins/the-name', { cacheable: true });
       expect(post).not.toHaveBeenCalled();
     });
 
@@ -78,7 +78,7 @@ describe('PluginsClient', () => {
 
       expect(result).toEqual('updated-existing-plugin');
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('Plugins/the-name');
+      expect(get).toHaveBeenCalledWith('Plugins/the-name', { cacheable: true });
       expect(post).toHaveBeenCalledTimes(1);
       expect(post).toHaveBeenCalledWith('Plugins/the-name', updatePayload);
     });
@@ -92,7 +92,7 @@ describe('PluginsClient', () => {
 
       expect(result).toEqual('created-plugin');
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('Plugins/the-name');
+      expect(get).toHaveBeenCalledWith('Plugins/the-name', { cacheable: true });
       expect(post).toHaveBeenCalledTimes(1);
       expect(post).toHaveBeenCalledWith('Plugins', payload);
     });
@@ -109,7 +109,7 @@ describe('PluginsClient', () => {
         expect(err).toEqual(exception);
 
         expect(get).toHaveBeenCalledTimes(1);
-        expect(get).toHaveBeenCalledWith('Plugins/the-name');
+        expect(get).toHaveBeenCalledWith('Plugins/the-name', { cacheable: true });
         expect(post).not.toHaveBeenCalled();
         done();
       }

--- a/packages/flex-plugins-api-client/src/clients/__tests__/releases.test.ts
+++ b/packages/flex-plugins-api-client/src/clients/__tests__/releases.test.ts
@@ -38,7 +38,7 @@ describe('ReleasesClient', () => {
 
     expect(result).toEqual('item');
     expect(get).toHaveBeenCalledTimes(1);
-    expect(get).toHaveBeenCalledWith('Releases/releaseId');
+    expect(get).toHaveBeenCalledWith('Releases/releaseId', { cacheable: true });
   });
 
   it('should create a release', async () => {

--- a/packages/flex-plugins-api-client/src/clients/configurations.ts
+++ b/packages/flex-plugins-api-client/src/clients/configurations.ts
@@ -59,7 +59,7 @@ export default class ConfigurationsClient {
    * @param configId  the configuration identifier
    */
   public async get(configId: string): Promise<ConfigurationResource> {
-    return this.client.get<ConfigurationResource>(ConfigurationsClient.getUrl(configId));
+    return this.client.get<ConfigurationResource>(ConfigurationsClient.getUrl(configId), { cacheable: true });
   }
 
   /**

--- a/packages/flex-plugins-api-client/src/clients/configuredPlugins.ts
+++ b/packages/flex-plugins-api-client/src/clients/configuredPlugins.ts
@@ -46,7 +46,7 @@ export default class ConfiguredPluginsClient {
    * @param configId the config identifier
    */
   public async list(configId: string): Promise<ConfiguredPluginResourcePage> {
-    return this.client.get<ConfiguredPluginResourcePage>(ConfiguredPluginsClient.getUrl(configId));
+    return this.client.get<ConfiguredPluginResourcePage>(ConfiguredPluginsClient.getUrl(configId), { cacheable: true });
   }
 
   /**
@@ -55,6 +55,6 @@ export default class ConfiguredPluginsClient {
    * @param id the plugin identifier
    */
   public async get(configId: string, id: string): Promise<ConfiguredPluginResource> {
-    return this.client.get<ConfiguredPluginResource>(ConfiguredPluginsClient.getUrl(configId, id));
+    return this.client.get<ConfiguredPluginResource>(ConfiguredPluginsClient.getUrl(configId, id), { cacheable: true });
   }
 }

--- a/packages/flex-plugins-api-client/src/clients/pluginVersions.ts
+++ b/packages/flex-plugins-api-client/src/clients/pluginVersions.ts
@@ -71,7 +71,7 @@ export default class PluginVersionsClient {
    * @param id the plugin version identifier
    */
   public async get(pluginId: string, id: string): Promise<PluginVersionResource> {
-    return this.client.get<PluginVersionResource>(PluginVersionsClient.getUrl(pluginId, id));
+    return this.client.get<PluginVersionResource>(PluginVersionsClient.getUrl(pluginId, id), { cacheable: true });
   }
 
   /**

--- a/packages/flex-plugins-api-client/src/clients/plugins.ts
+++ b/packages/flex-plugins-api-client/src/clients/plugins.ts
@@ -61,7 +61,7 @@ export default class PluginsClient {
    * @param id  the plugin identifier
    */
   public async get(id: string): Promise<PluginResource> {
-    return this.client.get<PluginResource>(PluginsClient.getUrl(id));
+    return this.client.get<PluginResource>(PluginsClient.getUrl(id), { cacheable: true });
   }
 
   /**

--- a/packages/flex-plugins-api-client/src/clients/releases.ts
+++ b/packages/flex-plugins-api-client/src/clients/releases.ts
@@ -59,7 +59,7 @@ export default class ReleasesClient {
    * @param releaseId the release identifier
    */
   public async get(releaseId: string): Promise<ReleaseResource> {
-    return this.client.get<ReleaseResource>(ReleasesClient.getUrl(releaseId));
+    return this.client.get<ReleaseResource>(ReleasesClient.getUrl(releaseId), { cacheable: true });
   }
 
   /**

--- a/packages/flex-plugins-api-utils/package-lock.json
+++ b/packages/flex-plugins-api-utils/package-lock.json
@@ -45,6 +45,20 @@
 				"follow-redirects": "1.5.10"
 			}
 		},
+		"axios-cache-adapter": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/axios-cache-adapter/-/axios-cache-adapter-2.5.0.tgz",
+			"integrity": "sha512-YcMPdMoqmSLoZx7A5YD/PdYGuX6/Y9M2tHBhaIXvXrPeGgNnbW7nb3+uArWlT53WGHLfclnu2voMmS7jGXVg6A==",
+			"requires": {
+				"cache-control-esm": "1.0.0",
+				"lodash": "^4.17.11"
+			}
+		},
+		"cache-control-esm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cache-control-esm/-/cache-control-esm-1.0.0.tgz",
+			"integrity": "sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g=="
+		},
 		"chalk": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
@@ -198,6 +212,11 @@
 				"foreach": "^2.0.5",
 				"has-symbols": "^1.0.1"
 			}
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"ms": {
 			"version": "2.0.0",

--- a/packages/flex-plugins-api-utils/package.json
+++ b/packages/flex-plugins-api-utils/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "axios-cache-adapter": "^2.5.0",
     "chalk": "^4.0.0",
     "qs": "^6.9.4",
     "util": "^0.12.3"

--- a/packages/flex-plugins-api-utils/src/__tests__/http.test.ts
+++ b/packages/flex-plugins-api-utils/src/__tests__/http.test.ts
@@ -28,7 +28,7 @@ describe('HttpClient', () => {
 
       expect(response).toEqual('the-result');
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('the-uri');
+      expect(get).toHaveBeenCalledWith('the-uri', {});
     });
   });
 
@@ -57,7 +57,7 @@ describe('HttpClient', () => {
 
       expect(result).toEqual([data]);
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('the-uri');
+      expect(get).toHaveBeenCalledWith('the-uri', undefined);
     });
   });
 
@@ -151,8 +151,13 @@ describe('HttpClient', () => {
 
   describe('transformResponse', () => {
     it('should transform response', () => {
+      const response = {
+        data: '123',
+        config: {},
+        request: {},
+      };
       // @ts-ignore
-      expect(HttpClient.transformResponse({ data: '123' })).toEqual('123');
+      expect(HttpClient.transformResponse(response)).toEqual('123');
     });
   });
 
@@ -192,6 +197,31 @@ describe('HttpClient', () => {
         expect((e as TwilioApiError).status).toEqual(err.response.data.status);
         done();
       }
+    });
+  });
+
+  describe('getRequestOption', () => {
+    it('should return empty object', () => {
+      const httpClient = new HttpClient(config);
+
+      // @ts-ignore
+      expect(httpClient.getRequestOption()).toEqual({});
+    });
+
+    it('should return default maxAge', () => {
+      const httpClient = new HttpClient(config);
+
+      // @ts-ignore
+      const maxAge = httpClient.cacheAge;
+      // @ts-ignore
+      expect(httpClient.getRequestOption({ cacheable: true })).toEqual({ cache: { maxAge } });
+    });
+
+    it('should return requested maxAge', () => {
+      const httpClient = new HttpClient(config);
+
+      // @ts-ignore
+      expect(httpClient.getRequestOption({ cacheable: true, cacheAge: 123 })).toEqual({ cache: { maxAge: 123 } });
     });
   });
 });


### PR DESCRIPTION
Add basic in-memory caching using https://github.com/RasCarlito/axios-cache-adapter. 

Unfortunately the way to get cacheable per endpoint on demand is to set cacheAge to zero for the global cache, and then set it per request. I opened an issue and this was the recommended approach: https://github.com/RasCarlito/axios-cache-adapter/issues/138