### PR TITLE
add pagination to the toolkit

### DIFF
--- a/packages/flex-plugins-api-toolkit/README.md
+++ b/packages/flex-plugins-api-toolkit/README.md
@@ -37,7 +37,7 @@ The toolkit provides the following commands.
 
 **Note**: If you are using the JWE token for authentication, then _all_ identifiers (such as `name`, `version`, etc) _must_ be the sid of the resource only.
 
-### .deploy(option)
+### .deploy(option: DeployOption): Promise\<DeployPlugin>
 
 This command deploys a new plugin version to Plugins API. This wrapper upserts a plugin (i.e., updates the plugin if it exists, otherwise creates a new plugin) and then creates a new version. 
 
@@ -71,7 +71,7 @@ interface DeployPlugin {
 }
 ```
 
-### .createConfiguration(option)
+### .createConfiguration(option: CreateConfigurationOption): Promise\<CreateConfiguration>
 
 This command creates a new configuration and installs a list of provided plugins. 
 
@@ -139,7 +139,7 @@ export interface CreateConfiguration {
 }
 ```
 
-### .release(option)
+### .release(option: ReleaseOption): Promise\<Release>
 
 This command creates a new release and activates the given configuration. 
 
@@ -164,7 +164,7 @@ interface Release {
 }
 ```
 
-### .describePlugin(option)
+### .describePlugin(option: DescribePluginOption): Promise\<DescribePlugin>
 
 This command returns information about a plugin and its versions. 
 
@@ -203,7 +203,7 @@ interface DescribePlugin {
 
 The field `isActive` is set to true if this plugin is part of an active release. The associated version that is part of the active release also has `isActive` set to true.
 
-### .describePluginVersion(option)
+### .describePluginVersion(option: DescribePluginVersionOption): Promise\<DescribePluginVersion>
 
 This command returns information about a plugin version.
 
@@ -242,7 +242,7 @@ interface DescribePluginVersion {
 
 The field `isActive` is set to true if this plugin version is part of an active release. 
 
-### .describeConfiguration(option)
+### .describeConfiguration(option: DescribeConfigurationOption): Promise\<DescribeConfiguration>
 
 This command returns information about a configuration, including a list of plugins included in it.
 
@@ -282,7 +282,7 @@ interface DescribeConfiguration {
 
 The field `isActive` is set to true if this configuration is part of an active release.
 
-### .describeRelease(option)
+### .describeRelease(option: DescribeReleaseOption): Promise\<Release>
 
 This command returns information about a release.
 
@@ -325,3 +325,153 @@ interface Release {
 ```
 
 The field `isActive` is set to true if this release is the active release.
+
+### .listPlugins(option: ListPluginsOption): Promise\<ListPluginsResource>
+
+This command returns a list of plugins. 
+
+The command takes an argument object of the format:
+
+```ts
+interface ListPluginsOption {
+  page?: Pagination;
+}
+```
+
+The command returns a promise of type:
+
+```ts
+interface ListPluginsResource {
+  plugins: Array<{
+    sid: string;
+    name: string;
+    friendlyName: string;
+    description: string;
+    isActive: boolean;
+    dateCreated: string;
+    dateUpdated: string;
+  }>;
+  meta: PaginationMeta;
+}
+```
+
+The field `isActive` is set to true if this plugin is part of an active release.
+
+### .listPluginVersions(option: ListPluginVersionsOption): Promise\<ListPluginVersionsResource>
+
+This command returns a list of plugins. 
+
+The command takes an argument object of the format:
+
+```ts
+interface ListPluginVersionsOption {
+  name: string;
+  page?: Pagination;
+}
+```
+
+The command returns a promise of type:
+
+```ts
+interface ListPluginVersionsResource {
+  plugin_versions: Array<{
+    sid: string;
+    pluginSid: string;
+    version: string;
+    url: string;
+    changelog: string;
+    isPrivate: boolean;
+    isActive: boolean;
+    dateCreated: string;  
+  }>;
+  meta: PaginationMeta;
+}
+```
+
+The field `isActive` is set to true if this plugin version is part of an active release.
+
+### .listConfigurations(option: ListConfigurationsOption): Promise\<ListConfigurationsResource>
+
+This command returns a list of plugins. 
+
+The command takes an argument object of the format:
+
+```ts
+interface ListConfigurationsOption {
+  page?: Pagination;
+}
+```
+
+The command returns a promise of type:
+
+```ts
+interface ListConfigurationsResource {
+  plugins: Array<{
+    sid: string;
+    version: string;
+    description: string;
+    isActive: boolean;
+    dateCreated: string;
+  }>;
+  meta: PaginationMeta;
+}
+```
+
+The field `isActive` is set to true if this configuration is part of an active release.
+
+### .listReleasess(option: ListReleasesOption): Promise\<ListReleasesResource>
+
+This command returns a list of plugins. 
+
+The command takes an argument object of the format:
+
+```ts
+interface ListReleasesOption {
+  page?: Pagination;
+}
+```
+
+The command returns a promise of type:
+
+```ts
+interface ListReleasesResource {
+  plugins: Array<{
+    sid: string;
+    configurationSid: string;
+    dateCreated: string;
+  }>;
+  meta: PaginationMeta;
+}
+```
+
+## Shared Types
+
+The `Pagination` interface is:
+
+```ts
+interface Pagination {
+  pageSize?: number;
+  page?: number;
+  pageToken?: string;
+}
+```
+
+The `PaginationMeta` interface is:
+
+```ts
+interface PaginationMeta {
+  meta: {
+    page: number;
+    page_size: number;
+    first_page_url: string;
+    previous_page_url: string;
+    url: string;
+    next_page_url?: string;
+    key: string;
+    next_token?: string;
+    previous_token?: string;
+  };
+}
+```
+
+where `next_token` and `previous_token` are extracted `PageToken` query parameter from the `next_page_url` and `previous_page_url` parameter respectively. 

--- a/packages/flex-plugins-api-toolkit/src/index.ts
+++ b/packages/flex-plugins-api-toolkit/src/index.ts
@@ -56,6 +56,14 @@ export {
   DescribeReleaseOption,
   DescribeRelease,
   InstalledPlugin,
+  ListPluginsOption,
+  ListPluginsResource,
+  ListPluginVersionsOption,
+  ListPluginVersionsResource,
+  ListConfigurationsOption,
+  ListConfigurationsResource,
+  ListReleasesOption,
+  ListReleasesResource,
 } from './scripts';
 
 export default class FlexPluginsAPIToolkit {

--- a/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listConfigurations.test.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listConfigurations.test.ts
@@ -1,6 +1,6 @@
 import { PluginServiceHTTPClient, ConfigurationsClient, ReleasesClient } from 'flex-plugins-api-client';
 
-import listConfigurationsScript, { ListConfigurations } from '../listConfigurations';
+import listConfigurationsScript, { ListConfigurationsResource } from '../listConfigurations';
 import { configuration, meta, release } from './mockStore';
 
 describe('ListConfigurationsScript', () => {
@@ -17,24 +17,38 @@ describe('ListConfigurationsScript', () => {
     jest.resetAllMocks();
   });
 
-  const assertConfiguration = (result: ListConfigurations[], isActive: boolean) => {
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
+  const assertConfiguration = (result: ListConfigurationsResource, isActive: boolean) => {
+    expect(result.configurations).toHaveLength(1);
+    expect(result.configurations[0]).toEqual({
       sid: configuration.sid,
       version: configuration.version,
       description: configuration.description,
       isActive,
       dateCreated: configuration.date_created,
     });
+    expect(result.meta).toEqual(meta);
   };
 
-  it('should list configurations with no release', async () => {
+  it('should list configurations with no release and pagination', async () => {
     list.mockResolvedValue({ configurations: [configuration], meta });
     active.mockResolvedValue(null);
 
-    const result = await script();
+    const result = await script({});
 
     expect(list).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledWith(undefined);
+    expect(active).toHaveBeenCalledTimes(1);
+    assertConfiguration(result, false);
+  });
+
+  it('should list configurations with no release and with pagination', async () => {
+    list.mockResolvedValue({ configurations: [configuration], meta });
+    active.mockResolvedValue(null);
+
+    const result = await script({ page: { pageSize: 1 } });
+
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledWith({ pageSize: 1 });
     expect(active).toHaveBeenCalledTimes(1);
     assertConfiguration(result, false);
   });
@@ -46,9 +60,10 @@ describe('ListConfigurationsScript', () => {
     list.mockResolvedValue({ configurations: [configuration], meta });
     active.mockResolvedValue(_release);
 
-    const result = await script();
+    const result = await script({});
 
     expect(list).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledWith(undefined);
     expect(active).toHaveBeenCalledTimes(1);
     assertConfiguration(result, false);
   });
@@ -60,9 +75,10 @@ describe('ListConfigurationsScript', () => {
     list.mockResolvedValue({ configurations: [configuration], meta });
     active.mockResolvedValue(_release);
 
-    const result = await script();
+    const result = await script({});
 
     expect(list).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledWith(undefined);
     expect(active).toHaveBeenCalledTimes(1);
     assertConfiguration(result, true);
   });

--- a/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listPluginVerions.test.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listPluginVerions.test.ts
@@ -5,7 +5,7 @@ import {
   ReleasesClient,
 } from 'flex-plugins-api-client';
 
-import listPluginVersionsScript, { ListPluginVersions } from '../listPluginVerions';
+import listPluginVersionsScript, { ListPluginVersions, ListPluginVersionsResource } from '../listPluginVerions';
 import { installedPlugin, meta, version, release } from './mockStore';
 
 describe('ListPluginsScriipt', () => {
@@ -25,9 +25,9 @@ describe('ListPluginsScriipt', () => {
     jest.resetAllMocks();
   });
 
-  const assertVersions = (result: ListPluginVersions[], isActive: boolean) => {
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
+  const assertVersions = (result: ListPluginVersionsResource, isActive: boolean) => {
+    expect(result.plugin_versions).toHaveLength(1);
+    expect(result.plugin_versions[0]).toEqual({
       sid: version.sid,
       pluginSid: version.plugin_sid,
       version: version.version,
@@ -37,16 +37,30 @@ describe('ListPluginsScriipt', () => {
       isActive,
       dateCreated: version.date_created,
     });
+    expect(result.meta).toEqual(meta);
   };
 
-  it('should list versions with no release', async () => {
+  it('should list versions with no release and pagination', async () => {
     listVersions.mockResolvedValue({ plugin_versions: [version], meta });
     active.mockResolvedValue(null);
 
     const result = await script(option);
 
     expect(listVersions).toHaveBeenCalledTimes(1);
-    expect(listVersions).toHaveBeenCalledWith(option.name);
+    expect(listVersions).toHaveBeenCalledWith(option.name, undefined);
+    expect(active).toHaveBeenCalledTimes(1);
+    expect(listConfiguredPlugins).not.toHaveBeenCalled();
+    assertVersions(result, false);
+  });
+
+  it('should list versions with no release and with pagination', async () => {
+    listVersions.mockResolvedValue({ plugin_versions: [version], meta });
+    active.mockResolvedValue(null);
+
+    const result = await script({ ...option, page: { pageSize: 1 } });
+
+    expect(listVersions).toHaveBeenCalledTimes(1);
+    expect(listVersions).toHaveBeenCalledWith(option.name, { pageSize: 1 });
     expect(active).toHaveBeenCalledTimes(1);
     expect(listConfiguredPlugins).not.toHaveBeenCalled();
     assertVersions(result, false);
@@ -63,7 +77,7 @@ describe('ListPluginsScriipt', () => {
     const result = await script(option);
 
     expect(listVersions).toHaveBeenCalledTimes(1);
-    expect(listVersions).toHaveBeenCalledWith(option.name);
+    expect(listVersions).toHaveBeenCalledWith(option.name, undefined);
     expect(active).toHaveBeenCalledTimes(1);
     expect(listConfiguredPlugins).toHaveBeenCalledTimes(1);
     expect(listConfiguredPlugins).toHaveBeenCalledWith(release.configuration_sid);
@@ -81,7 +95,7 @@ describe('ListPluginsScriipt', () => {
     const result = await script(option);
 
     expect(listVersions).toHaveBeenCalledTimes(1);
-    expect(listVersions).toHaveBeenCalledWith(option.name);
+    expect(listVersions).toHaveBeenCalledWith(option.name, undefined);
     expect(active).toHaveBeenCalledTimes(1);
     expect(listConfiguredPlugins).toHaveBeenCalledTimes(1);
     expect(listConfiguredPlugins).toHaveBeenCalledWith(release.configuration_sid);

--- a/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listPlugins.test.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listPlugins.test.ts
@@ -5,7 +5,7 @@ import {
   ReleasesClient,
 } from 'flex-plugins-api-client';
 
-import listPluginsScript, { ListPlugins } from '../listPlugins';
+import listPluginsScript, { ListPluginsResource } from '../listPlugins';
 import { installedPlugin, meta, plugin, release } from './mockStore';
 
 describe('ListPluginsScriipt', () => {
@@ -24,9 +24,9 @@ describe('ListPluginsScriipt', () => {
     jest.resetAllMocks();
   });
 
-  const assertPlugin = (result: ListPlugins[], isActive: boolean) => {
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
+  const assertPlugin = (result: ListPluginsResource, isActive: boolean) => {
+    expect(result.plugins).toHaveLength(1);
+    expect(result.plugins[0]).toEqual({
       sid: plugin.sid,
       name: plugin.unique_name,
       friendlyName: plugin.friendly_name,
@@ -35,15 +35,30 @@ describe('ListPluginsScriipt', () => {
       dateCreated: plugin.date_created,
       dateUpdated: plugin.date_updated,
     });
+    expect(result.meta).toEqual(meta);
   };
 
-  it('should list plugins with no release', async () => {
+  it('should list plugins with no release and pagination', async () => {
     listPlugins.mockResolvedValue({ plugins: [plugin], meta });
     active.mockResolvedValue(null);
 
-    const result = await script();
+    const result = await script({});
 
     expect(listPlugins).toHaveBeenCalledTimes(1);
+    expect(listPlugins).toHaveBeenCalledWith(undefined);
+    expect(active).toHaveBeenCalledTimes(1);
+    expect(listConfiguredPlugins).not.toHaveBeenCalled();
+    assertPlugin(result, false);
+  });
+
+  it('should list plugins with no release and with pagination', async () => {
+    listPlugins.mockResolvedValue({ plugins: [plugin], meta });
+    active.mockResolvedValue(null);
+
+    const result = await script({ page: { pageSize: 1 } });
+
+    expect(listPlugins).toHaveBeenCalledTimes(1);
+    expect(listPlugins).toHaveBeenCalledWith({ pageSize: 1 });
     expect(active).toHaveBeenCalledTimes(1);
     expect(listConfiguredPlugins).not.toHaveBeenCalled();
     assertPlugin(result, false);
@@ -57,7 +72,7 @@ describe('ListPluginsScriipt', () => {
     listConfiguredPlugins.mockResolvedValue({ plugins: [_installedPlugins], meta });
     active.mockResolvedValue(release);
 
-    const result = await script();
+    const result = await script({});
 
     expect(listPlugins).toHaveBeenCalledTimes(1);
     expect(active).toHaveBeenCalledTimes(1);
@@ -74,7 +89,7 @@ describe('ListPluginsScriipt', () => {
     listConfiguredPlugins.mockResolvedValue({ plugins: [_installedPlugins], meta });
     active.mockResolvedValue(release);
 
-    const result = await script();
+    const result = await script({});
 
     expect(listPlugins).toHaveBeenCalledTimes(1);
     expect(active).toHaveBeenCalledTimes(1);

--- a/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listReleases.test.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/__tests__/listReleases.test.ts
@@ -15,16 +15,33 @@ describe('ListReleasesScript', () => {
     jest.resetAllMocks();
   });
 
-  it('should list releases', async () => {
+  it('should list releases without pagination', async () => {
     list.mockResolvedValue({ releases: [release], meta });
-    const result = await script();
+    const result = await script({});
 
     expect(list).toHaveBeenCalledTimes(1);
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
+    expect(list).toHaveBeenCalledWith(undefined);
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0]).toEqual({
       sid: release.sid,
       configurationSid: release.configuration_sid,
       dateCreated: release.date_created,
     });
+    expect(result.meta).toEqual(meta);
+  });
+
+  it('should list releases with pagination', async () => {
+    list.mockResolvedValue({ releases: [release], meta });
+    const result = await script({ page: { pageSize: 1 } });
+
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledWith({ pageSize: 1 });
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0]).toEqual({
+      sid: release.sid,
+      configurationSid: release.configuration_sid,
+      dateCreated: release.date_created,
+    });
+    expect(result.meta).toEqual(meta);
   });
 });

--- a/packages/flex-plugins-api-toolkit/src/scripts/index.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/index.ts
@@ -1,4 +1,24 @@
+import { Pagination, PaginationMeta } from 'flex-plugins-api-client/dist/clients/client';
+
+// Plugins API resources
+export enum ResourceNames {
+  Plugins = 'plugins',
+  PluginVersions = 'plugin_versions',
+  Configurations = 'configurations',
+  Releases = 'releases',
+}
+
 export type Script<O, R> = (options: O) => Promise<R>;
+
+export interface Page {
+  page?: Pagination;
+}
+
+// The List Resources interface
+export type ListResource<K extends ResourceNames, T> = {
+  [key in K]: T[];
+} &
+  PaginationMeta;
 
 export { default as deployScript, DeployScript, DeployOption, DeployPlugin } from './deploy';
 export {
@@ -9,7 +29,13 @@ export {
   InstalledPlugin,
 } from './createConfiguration';
 export { default as releaseScript, ReleaseScript, ReleaseOption, Release } from './release';
-export { default as listPluginsScript, ListPluginsScripts, ListPlugins } from './listPlugins';
+export {
+  default as listPluginsScript,
+  ListPluginsScripts,
+  ListPluginsOption,
+  ListPlugins,
+  ListPluginsResource,
+} from './listPlugins';
 export {
   default as describePluginScript,
   DescribePluginScript,
@@ -21,6 +47,7 @@ export {
   ListPluginVersionsScripts,
   ListPluginVersionsOption,
   ListPluginVersions,
+  ListPluginVersionsResource,
 } from './listPluginVerions';
 export {
   default as describePluginVersionScript,
@@ -31,7 +58,9 @@ export {
 export {
   default as listConfigurationsScript,
   ListConfigurationsScript,
+  ListConfigurationsOption,
   ListConfigurations,
+  ListConfigurationsResource,
 } from './listConfigurations';
 export {
   default as describeConfigurationScript,
@@ -39,7 +68,13 @@ export {
   DescribeConfigurationOption,
   DescribeConfiguration,
 } from './describeConfiguration';
-export { default as listReleasesScript, ListReleasesScript, ListReleases } from './listReleases';
+export {
+  default as listReleasesScript,
+  ListReleasesScript,
+  ListReleasesOption,
+  ListReleases,
+  ListReleasesResource,
+} from './listReleases';
 export {
   default as describeReleaseScript,
   DescribeReleaseScript,

--- a/packages/flex-plugins-api-toolkit/src/scripts/listConfigurations.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/listConfigurations.ts
@@ -1,6 +1,8 @@
 import { ConfigurationsClient, ReleasesClient } from 'flex-plugins-api-client';
 
-import { Script } from '.';
+import { ListResource, Page, ResourceNames, Script } from '.';
+
+export type ListConfigurationsOption = Page;
 
 export interface ListConfigurations {
   sid: string;
@@ -10,23 +12,32 @@ export interface ListConfigurations {
   dateCreated: string;
 }
 
-export type ListConfigurationsScript = Script<{}, ListConfigurations[]>;
+export type ListConfigurationsResource = ListResource<ResourceNames.Configurations, ListConfigurations>;
+export type ListConfigurationsScript = Script<ListConfigurationsOption, ListConfigurationsResource>;
 
 /**
  * The .listConfigurations script. This script returns overall information about a Configuration
  * @param configurationsClient        the Public API {@link ConfigurationsClient}
  * @param releasesClient the Public API {@link ReleasesClient}
  */
-export default function listConfigurations(configurationsClient: ConfigurationsClient, releasesClient: ReleasesClient) {
-  return async (): Promise<ListConfigurations[]> => {
-    const [result, release] = await Promise.all([configurationsClient.list(), releasesClient.active()]);
+export default function listConfigurations(
+  configurationsClient: ConfigurationsClient,
+  releasesClient: ReleasesClient,
+): ListConfigurationsScript {
+  return async (option) => {
+    const [result, release] = await Promise.all([configurationsClient.list(option.page), releasesClient.active()]);
 
-    return result.configurations.map((configuration) => ({
+    const configurations = result.configurations.map((configuration) => ({
       sid: configuration.sid,
       version: configuration.version,
       description: configuration.description,
       isActive: Boolean(release && release.configuration_sid === configuration.sid),
       dateCreated: configuration.date_created,
     }));
+
+    return {
+      configurations,
+      meta: result.meta,
+    };
   };
 }

--- a/packages/flex-plugins-api-toolkit/src/scripts/listReleases.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/listReleases.ts
@@ -1,6 +1,8 @@
 import { ReleasesClient } from 'flex-plugins-api-client';
 
-import { Script } from '.';
+import { ListResource, Page, ResourceNames, Script } from '.';
+
+export type ListReleasesOption = Page;
 
 export interface ListReleases {
   sid: string;
@@ -8,20 +10,26 @@ export interface ListReleases {
   dateCreated: string;
 }
 
-export type ListReleasesScript = Script<{}, ListReleases[]>;
+export type ListReleasesResource = ListResource<ResourceNames.Releases, ListReleases>;
+export type ListReleasesScript = Script<ListReleasesOption, ListReleasesResource>;
 
 /**
  * The .listReleases script. This script returns overall information about a Release
  * @param releaseClient the Public API {@link ReleasesClient}
  */
-export default function listReleases(releaseClient: ReleasesClient) {
-  return async (): Promise<ListReleases[]> => {
-    const result = await releaseClient.list();
+export default function listReleases(releaseClient: ReleasesClient): ListReleasesScript {
+  return async (option) => {
+    const result = await releaseClient.list(option.page);
 
-    return result.releases.map((release) => ({
+    const releases = result.releases.map((release) => ({
       sid: release.sid,
       configurationSid: release.configuration_sid,
       dateCreated: release.date_created,
     }));
+
+    return {
+      releases,
+      meta: result.meta,
+    };
   };
 }


### PR DESCRIPTION
* Add pagination to the toolkit methods

__Note__: This is not backward compatible - the `list*` method interface has changed to include the `meta` field that is returned for pagination.