### PR TITLE
Fix removing duplicates from existing plugins

### DIFF
--- a/packages/flex-plugins-api-toolkit/src/scripts/__tests__/createConfiguration.test.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/__tests__/createConfiguration.test.ts
@@ -290,7 +290,7 @@ describe('CreateConfigurationScript', () => {
     // @ts-ignore
     listConfiguredPlugins.mockImplementation(async (configSid: string) => {
       if (configSid === release.configuration_sid) {
-        return Promise.resolve({ plugins: [configuredPlugin2], meta: null });
+        return Promise.resolve({ plugins: [configuredPlugin1, configuredPlugin2], meta: null });
       }
 
       return Promise.resolve({ plugins: [configuredPlugin1, configuredPlugin2], meta: null });

--- a/packages/flex-plugins-api-toolkit/src/scripts/createConfiguration.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/createConfiguration.ts
@@ -76,11 +76,7 @@ export default function createConfiguration(
       const existingPlugins = items.plugins
         .filter(
           (plugin) =>
-            !list.reduce(
-              (a: boolean, p: string) =>
-                a || p.indexOf(`${plugin.unique_name}@`) !== -1 || p.indexOf(`${plugin.plugin_sid}@`) !== -1,
-              false,
-            ),
+            !list.some((p) => p.indexOf(`${plugin.unique_name}@`) !== -1 || p.indexOf(`${plugin.plugin_sid}@`) !== -1),
         )
         .map((p) => `${p.plugin_sid}@${p.plugin_version_sid}`);
       list.push(...existingPlugins);

--- a/packages/flex-plugins-api-toolkit/src/scripts/createConfiguration.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/createConfiguration.ts
@@ -74,8 +74,13 @@ export default function createConfiguration(
     if (option.fromConfiguration) {
       const items = await configuredPluginClient.list(option.fromConfiguration);
       const existingPlugins = items.plugins
-        .filter((plugin) =>
-          list.every((p) => p.indexOf(`${plugin.unique_name}@`) === -1 || p.indexOf(`${plugin.plugin_sid}@`) !== -1),
+        .filter(
+          (plugin) =>
+            !list.reduce(
+              (a: boolean, p: string) =>
+                a || p.indexOf(`${plugin.unique_name}@`) !== -1 || p.indexOf(`${plugin.plugin_sid}@`) !== -1,
+              false,
+            ),
         )
         .map((p) => `${p.plugin_sid}@${p.plugin_version_sid}`);
       list.push(...existingPlugins);


### PR DESCRIPTION
removing existing plugins from addPlugins list had a bug, this change should fix this.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
